### PR TITLE
Fix schema version validation and bump version to v2.10.2

### DIFF
--- a/lib/adiwg/mdjson_schemas/version.rb
+++ b/lib/adiwg/mdjson_schemas/version.rb
@@ -1,6 +1,6 @@
 module ADIWG
     module MdjsonSchemas
         # Current schema version number
-        VERSION = "2.10.1"
+        VERSION = "2.10.2"
     end
 end

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -1,7 +1,7 @@
 {
   "id": "schema.json#",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "version": "2.10.1",
+  "version": "2.10.2",
   "description": "schema for ADIwg mdJSON metadata",
   "example": "../examples/mdJson.json",
   "type": "object",
@@ -56,7 +56,7 @@
         "version": {
           "type": "string",
           "description": "Specific version number of the schema standard.",
-          "pattern": "[0-9]\\.[0-9]\\.[0-9]"
+          "pattern": "[0-9]+\\.[0-9]+\\.[0-9]+"
         }
       }
     }


### PR DESCRIPTION
* Update schema.json to allow for schema versions with more than one major, minor, or patch digit. (use validation pattern "[0-9]+")

* Bump schema version to v2.10.2
