### PR TITLE
Fix release scripts and update lock files, bump version to 2.10.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    adiwg-mdjson_schemas (2.10.1)
+    adiwg-mdjson_schemas (2.10.2)
 
 GEM
   remote: https://rubygems.org/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mdjson-schemas",
-  "version": "2.10.1",
+  "version": "2.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mdjson-schemas",
-      "version": "2.10.1",
+      "version": "2.10.2",
       "license": "GPL-3.0",
       "devDependencies": {
         "ajv": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "build": "bundle && npm install && npm run prepublish",
     "clean": "sh scripts/clean.sh",
     "prepublish": "node scripts/prepublish.js",
-    "release": "npm run clean && npm run build && npm publish && gem build mdjson-schemas.gemspec && gem push mdjson-schemas-*.gem",
+    "release": "npm run clean && npm run build && npm publish && gem build adiwg-json_schemas.gemspec && gem push adiwg-mdjson_schemas-*.gem",
     "release:npm": "npm run build && npm publish",
-    "release:gem": "npm run clean && npm run build && gem build mdjson-schemas.gemspec && gem push mdjson-schemas-*.gem"
+    "release:gem": "npm run clean && npm run build && gem build adiwg-json_schemas.gemspec && gem push adiwg-mdjson_schemas-*.gem"
   },
   "files": [
     "examples",


### PR DESCRIPTION
Bump version to 2.10.2 in Gemfile.lock, package-lock.json and fix release scripts in package.json

This can be merged into develop whenever, it does not need to be merged into master until a new feature or bug fix is also being merged.